### PR TITLE
Fix code scanning alert no. 2: Server-side request forgery

### DIFF
--- a/pages/api/get-vendor.ts
+++ b/pages/api/get-vendor.ts
@@ -37,12 +37,12 @@ export default async function handler(
     if (req.method === 'POST') {
       const { id } = req.body;
 
-      if (!id) {
-        return res.status(400).json({ message: 'Vendor ID is required' });
+      if (!id || isNaN(id)) {
+        return res.status(400).json({ message: 'Valid vendor ID is required' });
       }
 
       // Requête pour un vendeur spécifique
-      const response = await axios.get(`${WC_API_DOMAIN}/wp-json/mvx/v1/vendors/${id}`, {
+      const response = await axios.get(`${WC_API_DOMAIN}/wp-json/mvx/v1/vendors/${encodeURIComponent(id)}`, {
         headers: {
           Authorization: `Basic ${Buffer.from(`${WC_CONSUMER_KEY}:${WC_CONSUMER_SECRET}`).toString('base64')}`
         }


### PR DESCRIPTION
Fixes [https://github.com/SDN33/M-m-StoreFront/security/code-scanning/2](https://github.com/SDN33/M-m-StoreFront/security/code-scanning/2)

To fix the problem, we need to validate and sanitize the `id` parameter before using it to construct the URL for the outgoing HTTP request. One way to do this is to ensure that the `id` parameter is a valid numeric value, as vendor IDs are typically numeric. This will prevent malicious input from being used in the URL.

- Validate the `id` parameter to ensure it is a numeric value.
- If the `id` is not valid, return a 400 Bad Request response.
- Use the validated `id` to construct the URL for the outgoing HTTP request.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
